### PR TITLE
Adapt Monitor for first occurrence

### DIFF
--- a/src/main/java/rabbitHutch/monitor/Main.java
+++ b/src/main/java/rabbitHutch/monitor/Main.java
@@ -21,10 +21,10 @@ public class Main {
 		Channel channel = connection.createChannel();
 
 		// Declare topology
-		Exchanges.declareBuildingPlan(channel);
+		Exchanges.declareBuildingState(channel);
 
 		String stateQueue = channel.queueDeclare().getQueue();
-		channel.queueBind(stateQueue, Exchanges.buildingPlan, "");
+		channel.queueBind(stateQueue, Exchanges.buildingState, "");
 
 		// Receiver (just print anything received)
 		channel.basicConsume(stateQueue, F.autoAck, new DefaultConsumer(channel) {


### PR DESCRIPTION
Monitor is used in Exercise 3 the first time. There it is supposed to get messages from the BuildingState exchange, instead of the BuildingPlan exchange.